### PR TITLE
Fix Cannot read properties of undefined (reading 'in_app')

### DIFF
--- a/src/lib/stacktrace.js
+++ b/src/lib/stacktrace.js
@@ -97,7 +97,7 @@ exports.stackLineParser = function(line) {
  * @returns {*[]}
  */
 exports.getCodeOfStackElement = async function (lineObj, limit = 10) {
-    if (!lineObj.in_app) {
+    if (!lineObj?.in_app) {
         return;
     }
 


### PR DESCRIPTION
src/lib/stacktrace.js: Method stackLineParser() returns undefined when the line cannot be matched which is then passed to getCodeOfStackElement() but not handled there. This leads to the following error when trying to log an exception with inspector: Cannot read properties of undefined (reading 'in_app')